### PR TITLE
nil pointer is also considered an empty map.

### DIFF
--- a/internal/generic_types/containers.go
+++ b/internal/generic_types/containers.go
@@ -622,11 +622,18 @@ func newGenericMapType(items []GenericMapItem) *GenericMapType {
 
 // Len returns the number of items in m.
 func (m *GenericMapType) Len() int {
+	if m == nil {
+		return 0
+	}
 	return int(m.len)
 }
 
 // Load returns value identified by key. ok is set to true if key exists in the map, false otherwise.
 func (m *GenericMapType) Load(key GenericMapKeyType) (value GenericMapValueType, ok bool) {
+	var zeroValue GenericMapValueType
+	if m == nil {
+		return zeroValue, false
+	}
 	bucket := m.backingVector.Get(m.pos(key))
 	if bucket != nil {
 		for _, item := range bucket {
@@ -636,12 +643,15 @@ func (m *GenericMapType) Load(key GenericMapKeyType) (value GenericMapValueType,
 		}
 	}
 
-	var zeroValue GenericMapValueType
 	return zeroValue, false
 }
 
 // Store returns a new GenericMapType containing value identified by key.
 func (m *GenericMapType) Store(key GenericMapKeyType, value GenericMapValueType) *GenericMapType {
+	if m == nil {
+		return NewGenericMapType(GenericMapItem{Key: key, Value: value})
+	}
+
 	// Grow backing vector if load factor is too high
 	if m.Len() >= m.backingVector.Len()*int(upperMapLoadFactor) {
 		buckets := newPrivateGenericMapItemBuckets(m.Len() + 1)
@@ -677,6 +687,9 @@ func (m *GenericMapType) Store(key GenericMapKeyType, value GenericMapValueType)
 
 // Delete returns a new GenericMapType without the element identified by key.
 func (m *GenericMapType) Delete(key GenericMapKeyType) *GenericMapType {
+	if m == nil {
+		return nil
+	}
 	pos := m.pos(key)
 	bucket := m.backingVector.Get(pos)
 	if bucket != nil {
@@ -713,6 +726,9 @@ func (m *GenericMapType) Delete(key GenericMapKeyType) *GenericMapType {
 // Range calls f repeatedly passing it each key and value as argument until either
 // all elements have been visited or f returns false.
 func (m *GenericMapType) Range(f func(GenericMapKeyType, GenericMapValueType) bool) {
+	if m == nil {
+		return
+	}
 	m.backingVector.Range(func(bucket privateGenericMapItemBucket) bool {
 		for _, item := range bucket {
 			if !f(item.Key, item.Value) {

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -362,11 +362,18 @@ func new{{.MapTypeName}}(items []{{.MapItemTypeName}}) *{{.MapTypeName}} {
 
 // Len returns the number of items in m.
 func (m *{{.MapTypeName}}) Len() int {
+	if m == nil {
+		return 0
+	}
 	return int(m.len)
 }
 
 // Load returns value identified by key. ok is set to true if key exists in the map, false otherwise.
 func (m *{{.MapTypeName}}) Load(key {{.MapKeyTypeName}}) (value {{.MapValueTypeName}}, ok bool) {
+	var zeroValue {{.MapValueTypeName}}
+	if m == nil {
+		return zeroValue, false
+	}
 	bucket := m.backingVector.Get(m.pos(key))
 	if bucket != nil {
 		for _, item := range bucket {
@@ -376,12 +383,15 @@ func (m *{{.MapTypeName}}) Load(key {{.MapKeyTypeName}}) (value {{.MapValueTypeN
 		}
 	}
 
-	var zeroValue {{.MapValueTypeName}}
 	return zeroValue, false
 }
 
 // Store returns a new {{.MapTypeName}} containing value identified by key.
 func (m *{{.MapTypeName}}) Store(key {{.MapKeyTypeName}}, value {{.MapValueTypeName}}) *{{.MapTypeName}} {
+	if m == nil {
+		return New{{.MapTypeName}}({{.MapItemTypeName}}{Key: key, Value: value})
+	}
+
 	// Grow backing vector if load factor is too high
 	if m.Len() >= m.backingVector.Len()*int(upperMapLoadFactor) {
 		buckets := newPrivate{{.MapItemTypeName}}Buckets(m.Len() + 1)
@@ -417,6 +427,9 @@ func (m *{{.MapTypeName}}) Store(key {{.MapKeyTypeName}}, value {{.MapValueTypeN
 
 // Delete returns a new {{.MapTypeName}} without the element identified by key.
 func (m *{{.MapTypeName}}) Delete(key {{.MapKeyTypeName}}) *{{.MapTypeName}} {
+	if m == nil {
+		return nil
+	}
 	pos := m.pos(key)
 	bucket := m.backingVector.Get(pos)
 	if bucket != nil {
@@ -453,6 +466,9 @@ func (m *{{.MapTypeName}}) Delete(key {{.MapKeyTypeName}}) *{{.MapTypeName}} {
 // Range calls f repeatedly passing it each key and value as argument until either
 // all elements have been visited or f returns false.
 func (m *{{.MapTypeName}}) Range(f func({{.MapKeyTypeName}}, {{.MapValueTypeName}}) bool) {
+	if m == nil {
+		return
+	}
 	m.backingVector.Range(func(bucket private{{.MapItemTypeName}}Bucket) bool {
 		for _, item := range bucket {
 			if !f(item.Key, item.Value) {


### PR DESCRIPTION
I found it awkward to have to do New*Map before actually using them. With these pretty small changes you can just e.g. var m FooBarMap and play with it directly.

Similar changes to vectors/sets would be nice too, but I did not need them and due to performance reasons I think I am refactoring my design away from this; golang gc is stupidly expensive so these datastructures wind up being much slower than I thought. Live and learn :-) 